### PR TITLE
docs(pre-commit): Added Branch Name Validation to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,12 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+        # This one will be used to enforce branches follow the naming convention
+      - id: no-commit-to-branch
+        alias: validate-branch-name
+        args: [
+          "--pattern", '^(?!(build|ci|docs|feat|fix|perf|refactor|style|test)\/(issue-\d+|no-ref)\/[a-zA-Z0-9\-]+)'
+        ]
   # Run `vagrant validate` on commit
   - repo: https://github.com/ashwin153/pre-commit-vagrant
     rev: v1.1.0

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ The structure is as follows: `type/reference/summary`
 
 The logic is:
 - `type`: refers to the the same types as the ones used in our [commit structure definition](#commit-structure)
+  - *build*: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+  - *ci*: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+  - *docs*: Documentation only changes
+  - *feat*: A new feature
+  - *fix*: A bug fix
+  - *perf*: A code change that improves performance
+  - *refactor*: A code change that neither fixes a bug nor adds a feature
+  - *style*: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+  - *test*: Adding missing tests or correcting existing tests
 - `reference`: Points to a GitHub issue
   - Should look like `issue-##`
   - If there is no issue, just use `no-ref`


### PR DESCRIPTION
Whenever a commit is attempted to be created to a branch that is invalid, pre-commit will fail.\nAlso added the valid *commit types* in the README, just for ease of access and since it's also relevant for the branch naming.

Closes 23